### PR TITLE
Use real names for overloaded methods

### DIFF
--- a/lib/empirical.rb
+++ b/lib/empirical.rb
@@ -105,7 +105,7 @@ module Empirical
 			def #{method_name}(*args, **kwargs, &block)
 				::Empirical::OVERLOADED_METHODS[self.method(:#{method_name}).owner][:#{method_name}].each do |sig|
 					if sig.positional_params_type === args && sig.keyword_params_type === kwargs
-					  return __send__(sig.method_ident, *args, **kwargs, &block)
+						return sig.method.bind_call(self, *args, **kwargs, &block)
 					end
 				end
 

--- a/lib/empirical/signature.rb
+++ b/lib/empirical/signature.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class Empirical::Signature < Literal::Data
-	prop :method_ident, Symbol
+	prop :method, UnboundMethod
 	prop :positional_params_type, Empirical::PositionalParamsType
 	prop :keyword_params_type, Empirical::KeywordParamsType
 end

--- a/lib/empirical/signature_processor.rb
+++ b/lib/empirical/signature_processor.rb
@@ -65,16 +65,6 @@ class Empirical::SignatureProcessor < Empirical::BaseProcessor
 
 			overloading = @block_stack.any? { it.name == :overload }
 
-			if overloading
-				overloaded_name = unique_method_ident(signature.slice)
-
-				@annotations << [
-					(start = signature.message_loc.start_offset),
-					signature.message_loc.end_offset - start,
-					overloaded_name,
-				]
-			end
-
 			case signature
 			# parameterless method defs (e.g. `fun foo` or `fun foo()`)
 			in Prism::LocalVariableReadNode | Prism::ConstantReadNode
@@ -207,7 +197,7 @@ class Empirical::SignatureProcessor < Empirical::BaseProcessor
 			pre_end_buffer << ")"
 
 			if overloading
-				post_end_buffer << "((::Empirical::OVERLOADED_METHODS[self] ||= {})[:#{method_name}] ||= []) << ::Empirical::Signature.new(method_ident: :#{overloaded_name}, positional_params_type: ::Empirical::PositionalParamsType.new(types: [#{positional_params_type_buffer.join(', ')}], rest: #{positional_splat_type_buffer.first || 'nil'}), keyword_params_type: ::Empirical::KeywordParamsType.new(types: {#{keyword_params_type_buffer.join(', ')}}, rest: #{keyword_splat_type_buffer.first || 'nil'}))"
+				post_end_buffer << "((::Empirical::OVERLOADED_METHODS[self] ||= {})[:#{method_name}] ||= []) << ::Empirical::Signature.new(method: instance_method(:#{method_name}), positional_params_type: ::Empirical::PositionalParamsType.new(types: [#{positional_params_type_buffer.join(', ')}], rest: #{positional_splat_type_buffer.first || 'nil'}), keyword_params_type: ::Empirical::KeywordParamsType.new(types: {#{keyword_params_type_buffer.join(', ')}}, rest: #{keyword_splat_type_buffer.first || 'nil'}))"
 				post_end_buffer << "::Empirical.generate_root_overloaded_method(self, :#{method_name})"
 			end
 


### PR DESCRIPTION
This changes our overloading implementation to use the real name when defining each branch method. Right after defining the method, we grab a reference to it as an `UnboundMethod` object. Then we override it with the root method.

This technique means we don’t report each overload branch as its own method and when a branch errors, it reports the correct method name.